### PR TITLE
OAuth provider

### DIFF
--- a/lib/grapevine/accounts/user.ex
+++ b/lib/grapevine/accounts/user.ex
@@ -6,6 +6,7 @@ defmodule Grapevine.Accounts.User do
   use Grapevine.Schema
 
   alias Grapevine.Accounts
+  alias Grapevine.Authorizations.Authorization
   alias Grapevine.Characters.Character
 
   schema "users" do
@@ -17,6 +18,7 @@ defmodule Grapevine.Accounts.User do
     field(:token, Ecto.UUID)
     field(:registration_key, Ecto.UUID, read_after_writes: true)
 
+    has_many(:authorizations, Authorization)
     has_many(:characters, Character)
 
     timestamps()

--- a/lib/grapevine/accounts/user.ex
+++ b/lib/grapevine/accounts/user.ex
@@ -10,6 +10,7 @@ defmodule Grapevine.Accounts.User do
   alias Grapevine.Characters.Character
 
   schema "users" do
+    field(:uid, Ecto.UUID, read_after_writes: true)
     field(:username, :string)
     field(:email, :string)
     field(:password, :string, virtual: true)

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -15,11 +15,20 @@ defmodule Grapevine.Authorizations do
   """
   def start_auth(user, game, params) do
     with {:ok, redirect_uri} <- Map.fetch(params, "redirect_uri") do
+      scopes =
+        params
+        |> Map.get("scope", "")
+        |> String.split(" ")
+        |> Enum.sort()
+
+      params = Map.put(params, "scopes", scopes)
+
       opts = [
         user_id: user.id,
         game_id: game.id,
         redirect_uri: redirect_uri,
         active: true,
+        scopes: scopes,
       ]
 
       case Repo.get_by(Authorization, opts) do

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -14,6 +14,28 @@ defmodule Grapevine.Authorizations do
   Creates an authorization record
   """
   def start_auth(user, game, params) do
+    with {:ok, redirect_uri} <- Map.fetch(params, "redirect_uri") do
+      opts = [
+        user_id: user.id,
+        game_id: game.id,
+        redirect_uri: redirect_uri,
+        active: true,
+      ]
+
+      case Repo.get_by(Authorization, opts) do
+        nil ->
+          create_authorization(user, game, params)
+
+        authorization ->
+          {:ok, authorization}
+      end
+    else
+      _ ->
+        create_authorization(user, game, params)
+    end
+  end
+
+  defp create_authorization(user, game, params) do
     user
     |> Ecto.build_assoc(:authorizations)
     |> Authorization.create_changeset(game, params)

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -128,7 +128,7 @@ defmodule Grapevine.Authorizations do
     with {:ok, client_id} <- Ecto.UUID.cast(client_id),
          {:ok, game} <- Games.get_by(client_id: client_id),
          {:ok, code} <- Ecto.UUID.cast(code) do
-      case Repo.get_by(Authorization, game_id: game.id, redirect_uri: redirect_uri, code: code) do
+      case Repo.get_by(Authorization, game_id: game.id, redirect_uri: redirect_uri, code: code, active: true) do
         nil ->
           {:error, :invalid_grant}
 

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -55,6 +55,21 @@ defmodule Grapevine.Authorizations do
     end
   end
 
+  def get_token(token) do
+    with {:ok, token} <- Ecto.UUID.cast(token) do
+      case Repo.get_by(AccessToken, access_token: token) do
+        nil ->
+          {:error, :not_found}
+
+        access_token ->
+          {:ok, Repo.preload(access_token, [authorization: [:user]])}
+      end
+    else
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
   @doc """
   Authorize an authorization
 

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -1,0 +1,100 @@
+defmodule Grapevine.Authorizations do
+  @moduledoc """
+  Authorize remote logins
+  """
+
+  alias Backbone.Games
+  alias Grapevine.Authorizations.AccessToken
+  alias Grapevine.Authorizations.Authorization
+  alias Grapevine.Repo
+
+  @doc """
+  Start authorization
+
+  Creates an authorization record
+  """
+  def start_auth(user, game, params) do
+    user
+    |> Ecto.build_assoc(:authorizations)
+    |> Authorization.create_changeset(game, params)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Get a user's authorization record
+  """
+  def get(user, id) do
+    case Repo.get_by(Authorization, user_id: user.id, id: id) do
+      nil ->
+        {:error, :not_found}
+
+      authorization ->
+        {:ok, authorization}
+    end
+  end
+
+  @doc """
+  Authorize an authorization
+
+  Marks it as active
+  """
+  def authorize(authorization) do
+    authorization
+    |> Authorization.authorize_changeset()
+    |> Repo.update()
+  end
+
+  @doc """
+  Deny an authorization
+
+  Deletes the authorization record
+  """
+  def deny(authorization) do
+    Repo.delete(authorization)
+  end
+
+  @doc """
+  Get an authorized redirect uri
+
+  Includes the authorization code
+  """
+  def authorized_redirect_uri(authorization) do
+    uri = URI.parse(authorization.redirect_uri)
+    query = URI.encode_query(%{code: authorization.code, state: authorization.state})
+    uri = %{uri | query: query}
+    {:ok, URI.to_string(uri)}
+  end
+
+  @doc """
+  Get a denied redirect uri
+  """
+  def denied_redirect_uri(authorization) do
+    uri = URI.parse(authorization.redirect_uri)
+    query = URI.encode_query(%{error: :access_denied, state: authorization.state})
+    uri = %{uri | query: query}
+    {:ok, URI.to_string(uri)}
+  end
+
+  @doc """
+  Create an access token
+  """
+  def create_token(client_id, redirect_uri, code) do
+    with {:ok, client_id} <- Ecto.UUID.cast(client_id),
+         {:ok, game} <- Games.get_by(client_id: client_id),
+         {:ok, code} <- Ecto.UUID.cast(code) do
+      case Repo.get_by(Authorization, game_id: game.id, redirect_uri: redirect_uri, code: code) do
+        nil ->
+          {:error, :invalid_grant}
+
+        authorization ->
+          authorization
+          |> Ecto.build_assoc(:access_tokens)
+          |> AccessToken.create_changeset()
+          |> Repo.insert()
+      end
+    else
+      _ ->
+        {:error, :invalid_grant}
+    end
+  end
+end

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -36,12 +36,18 @@ defmodule Grapevine.Authorizations do
           create_authorization(user, game, params)
 
         authorization ->
-          {:ok, authorization}
+          refresh_code(authorization)
       end
     else
       _ ->
         create_authorization(user, game, params)
     end
+  end
+
+  defp refresh_code(authorization) do
+    authorization
+    |> Authorization.refresh_code_changeset()
+    |> Repo.update()
   end
 
   defp create_authorization(user, game, params) do
@@ -151,7 +157,8 @@ defmodule Grapevine.Authorizations do
     end
   end
 
-  defp mark_as_used(authorization) do
+  @doc false
+  def mark_as_used(authorization) do
     authorization
     |> Authorization.used_changeset()
     |> Repo.update()

--- a/lib/grapevine/authorizations.ex
+++ b/lib/grapevine/authorizations.ex
@@ -143,10 +143,18 @@ defmodule Grapevine.Authorizations do
 
   @doc false
   def create_token(authorization = %Authorization{}) do
+    with {:ok, authorization} <- mark_as_used(authorization) do
+      authorization
+      |> Ecto.build_assoc(:access_tokens)
+      |> AccessToken.create_changeset()
+      |> Repo.insert()
+    end
+  end
+
+  defp mark_as_used(authorization) do
     authorization
-    |> Ecto.build_assoc(:access_tokens)
-    |> AccessToken.create_changeset()
-    |> Repo.insert()
+    |> Authorization.used_changeset()
+    |> Repo.update()
   end
 
   @doc """

--- a/lib/grapevine/authorizations/access_token.ex
+++ b/lib/grapevine/authorizations/access_token.ex
@@ -1,0 +1,30 @@
+defmodule Grapevine.Authorizations.AccessToken do
+  @moduledoc """
+  Access token schema
+  """
+
+  use Grapevine.Schema
+
+  alias Grapevine.Authorizations.Authorization
+
+  @one_hour 60 * 60
+
+  schema "access_tokens" do
+    field(:access_token, Ecto.UUID)
+    field(:refresh_token, Ecto.UUID)
+    field(:active, :boolean, default: false)
+    field(:expires_in, :integer, default: @one_hour)
+
+    belongs_to(:authorization, Authorization)
+
+    timestamps()
+  end
+
+  def create_changeset(struct) do
+    struct
+    |> change()
+    |> put_change(:active, true)
+    |> put_change(:access_token, UUID.uuid4())
+    |> put_change(:refresh_token, UUID.uuid4())
+  end
+end

--- a/lib/grapevine/authorizations/access_token.ex
+++ b/lib/grapevine/authorizations/access_token.ex
@@ -9,6 +9,7 @@ defmodule Grapevine.Authorizations.AccessToken do
 
   @one_hour 60 * 60
 
+  @primary_key {:id, :binary_id, autogenerate: true}
   schema "access_tokens" do
     field(:access_token, Ecto.UUID)
     field(:refresh_token, Ecto.UUID)

--- a/lib/grapevine/authorizations/authorization.ex
+++ b/lib/grapevine/authorizations/authorization.ex
@@ -49,6 +49,12 @@ defmodule Grapevine.Authorizations.Authorization do
     |> put_change(:code, nil)
   end
 
+  def refresh_code_changeset(struct) do
+    struct
+    |> change()
+    |> put_change(:code, UUID.uuid4())
+  end
+
   defp validate_scopes(changeset) do
     case get_field(changeset, :scopes) do
       [] ->

--- a/lib/grapevine/authorizations/authorization.ex
+++ b/lib/grapevine/authorizations/authorization.ex
@@ -31,6 +31,7 @@ defmodule Grapevine.Authorizations.Authorization do
     |> cast(params, [:redirect_uri, :state, :scopes])
     |> validate_required([:redirect_uri, :state, :scopes])
     |> validate_redirect_uri()
+    |> validate_redirect_uri_known(game)
     |> validate_scopes()
     |> put_change(:game_id, game.id)
     |> put_change(:code, UUID.uuid4())
@@ -137,6 +138,22 @@ defmodule Grapevine.Authorizations.Authorization do
 
       _ ->
         add_error(changeset, :redirect_uri, "must be a fully qualified URI")
+    end
+  end
+
+  defp validate_redirect_uri_known(changeset, game) do
+    case get_field(changeset, :redirect_uri) do
+      nil ->
+        changeset
+
+      redirect_uri ->
+        case redirect_uri in game.redirect_uris do
+          true ->
+            changeset
+
+          false ->
+            add_error(changeset, :redirect_uri, "does not match a know URI")
+        end
     end
   end
 end

--- a/lib/grapevine/authorizations/authorization.ex
+++ b/lib/grapevine/authorizations/authorization.ex
@@ -1,0 +1,40 @@
+defmodule Grapevine.Authorizations.Authorization do
+  @moduledoc """
+  Authorization schema
+  """
+
+  use Grapevine.Schema
+
+  alias Backbone.Games.Game
+  alias Grapevine.Accounts.User
+  alias Grapevine.Authorizations.AccessToken
+
+  schema "authorizations" do
+    field(:redirect_uri, :string)
+    field(:state, :string)
+    field(:scopes, {:array, :string}, default: [])
+    field(:code, Ecto.UUID)
+    field(:active, :boolean, default: false)
+
+    belongs_to(:user, User)
+    belongs_to(:game, Game)
+
+    has_many(:access_tokens, AccessToken)
+
+    timestamps()
+  end
+
+  def create_changeset(struct, game, params) do
+    struct
+    |> cast(params, [:redirect_uri, :state, :scopes])
+    |> validate_required([:redirect_uri, :state, :scopes])
+    |> put_change(:game_id, game.id)
+    |> put_change(:code, UUID.uuid4())
+  end
+
+  def authorize_changeset(struct) do
+    struct
+    |> change()
+    |> put_change(:active, true)
+  end
+end

--- a/lib/grapevine/authorizations/authorization.ex
+++ b/lib/grapevine/authorizations/authorization.ex
@@ -42,6 +42,12 @@ defmodule Grapevine.Authorizations.Authorization do
     |> put_change(:active, true)
   end
 
+  def used_changeset(struct) do
+    struct
+    |> change()
+    |> put_change(:code, nil)
+  end
+
   defp validate_scopes(changeset) do
     case get_field(changeset, :scopes) do
       [] ->

--- a/lib/grapevine/authorizations/authorization.ex
+++ b/lib/grapevine/authorizations/authorization.ex
@@ -28,6 +28,7 @@ defmodule Grapevine.Authorizations.Authorization do
     struct
     |> cast(params, [:redirect_uri, :state, :scopes])
     |> validate_required([:redirect_uri, :state, :scopes])
+    |> validate_redirect_uri()
     |> put_change(:game_id, game.id)
     |> put_change(:code, UUID.uuid4())
   end
@@ -36,5 +37,72 @@ defmodule Grapevine.Authorizations.Authorization do
     struct
     |> change()
     |> put_change(:active, true)
+  end
+
+  defp validate_redirect_uri(changeset) do
+    case get_field(changeset, :redirect_uri) do
+      nil ->
+        changeset
+
+      redirect_uri ->
+        uri = URI.parse(redirect_uri)
+
+        changeset
+        |> validate_redirect_uri_scheme(uri)
+        |> validate_redirect_uri_host(uri)
+        |> validate_redirect_uri_path(uri)
+        |> validate_redirect_uri_query(uri)
+        |> validate_redirect_uri_fragment(uri)
+    end
+  end
+
+  defp validate_redirect_uri_scheme(changeset, uri) do
+    case uri.scheme do
+      "https" ->
+        changeset
+
+      _ ->
+        add_error(changeset, :redirect_uri, "must be https")
+    end
+  end
+
+  defp validate_redirect_uri_host(changeset, uri) do
+    case uri.host do
+      nil ->
+        add_error(changeset, :redirect_uri, "must be a fully qualified URI")
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp validate_redirect_uri_path(changeset, uri) do
+    case uri.path do
+      nil ->
+        add_error(changeset, :redirect_uri, "must be a fully qualified URI")
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp validate_redirect_uri_query(changeset, uri) do
+    case uri.query do
+      nil ->
+        changeset
+
+      _ ->
+        add_error(changeset, :redirect_uri, "must be a fully qualified URI")
+    end
+  end
+
+  defp validate_redirect_uri_fragment(changeset, uri) do
+    case uri.fragment do
+      nil ->
+        changeset
+
+      _ ->
+        add_error(changeset, :redirect_uri, "must be a fully qualified URI")
+    end
   end
 end

--- a/lib/web/controllers/oauth/authorization_controller.ex
+++ b/lib/web/controllers/oauth/authorization_controller.ex
@@ -1,0 +1,47 @@
+defmodule Web.Oauth.AuthorizationController do
+  use Web, :controller
+
+  plug(Web.Plugs.FetchGame when action in [:new])
+
+  alias Grapevine.Authorizations
+
+  def new(conn, params) do
+    %{current_user: user, client_game: game} = conn.assigns
+
+    with {:ok, authorization} <- Authorizations.start_auth(user, game, params) do
+      conn
+      |> assign(:authorization, authorization)
+      |> render("new.html")
+    end
+  end
+
+  def update(conn, %{"authorization" => %{"id" => id, "allow" => "true"}}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, authorization} <- Authorizations.get(user, id),
+         {:ok, authorization} <- Authorizations.authorize(authorization),
+         {:ok, uri} <- Authorizations.authorized_redirect_uri(authorization) do
+      conn |> redirect(external: uri)
+    else
+      _ ->
+        conn
+        |> put_flash(:error, "Unknown issue authenticating. Please try again")
+        |> redirect(to: page_path(conn, :index))
+    end
+  end
+
+  def update(conn, %{"authorization" => %{"id" => id, "allow" => "false"}}) do
+    %{current_user: user} = conn.assigns
+
+    with {:ok, authorization} <- Authorizations.get(user, id),
+         {:ok, uri} <- Authorizations.denied_redirect_uri(authorization),
+         {:ok, _authorization} <- Authorizations.deny(authorization) do
+      conn |> redirect(external: uri)
+    else
+      _ ->
+        conn
+        |> put_flash(:error, "Unknown issue authenticating. Please try again")
+        |> redirect(to: page_path(conn, :index))
+    end
+  end
+end

--- a/lib/web/controllers/oauth/authorization_controller.ex
+++ b/lib/web/controllers/oauth/authorization_controller.ex
@@ -20,7 +20,7 @@ defmodule Web.Oauth.AuthorizationController do
           |> render("new.html")
       end
     else
-      {:error, changeset} ->
+      {:error, _} ->
         conn
         |> put_flash(:error, "Unknown issue authenticating. Please try again")
         |> redirect(to: page_path(conn, :index))

--- a/lib/web/controllers/oauth/authorization_controller.ex
+++ b/lib/web/controllers/oauth/authorization_controller.ex
@@ -6,9 +6,10 @@ defmodule Web.Oauth.AuthorizationController do
   alias Grapevine.Authorizations
 
   def new(conn, params) do
-    %{current_user: user, client_game: game} = conn.assigns
+    %{current_user: user} = conn.assigns
 
-    with {:ok, authorization} <- Authorizations.start_auth(user, game, params) do
+    with %{client_game: game} <- conn.assigns,
+         {:ok, authorization} <- Authorizations.start_auth(user, game, params) do
       case authorization.active do
         true ->
          {:ok, uri} = Authorizations.authorized_redirect_uri(authorization)
@@ -20,7 +21,7 @@ defmodule Web.Oauth.AuthorizationController do
           |> render("new.html")
       end
     else
-      {:error, _} ->
+      _ ->
         conn
         |> put_flash(:error, "Unknown issue authenticating. Please try again")
         |> redirect(to: page_path(conn, :index))

--- a/lib/web/controllers/oauth/authorization_controller.ex
+++ b/lib/web/controllers/oauth/authorization_controller.ex
@@ -19,6 +19,11 @@ defmodule Web.Oauth.AuthorizationController do
           |> assign(:authorization, authorization)
           |> render("new.html")
       end
+    else
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "Unknown issue authenticating. Please try again")
+        |> redirect(to: page_path(conn, :index))
     end
   end
 

--- a/lib/web/controllers/oauth/authorization_controller.ex
+++ b/lib/web/controllers/oauth/authorization_controller.ex
@@ -9,9 +9,16 @@ defmodule Web.Oauth.AuthorizationController do
     %{current_user: user, client_game: game} = conn.assigns
 
     with {:ok, authorization} <- Authorizations.start_auth(user, game, params) do
-      conn
-      |> assign(:authorization, authorization)
-      |> render("new.html")
+      case authorization.active do
+        true ->
+         {:ok, uri} = Authorizations.authorized_redirect_uri(authorization)
+         conn |> redirect(external: uri)
+
+        false ->
+          conn
+          |> assign(:authorization, authorization)
+          |> render("new.html")
+      end
     end
   end
 

--- a/lib/web/controllers/oauth/token_controller.ex
+++ b/lib/web/controllers/oauth/token_controller.ex
@@ -1,0 +1,16 @@
+defmodule Web.Oauth.TokenController do
+  use Web, :controller
+
+  alias Grapevine.Authorizations
+
+  def create(conn, params = %{"grant_type" => "authorization_code"}) do
+    with {:ok, code} <- Map.fetch(params, "code"),
+         {:ok, client_id} <- Map.fetch(params, "client_id"),
+         {:ok, redirect_uri} <- Map.fetch(params, "redirect_uri"),
+         {:ok, access_token} <- Authorizations.create_token(client_id, redirect_uri, code) do
+      conn
+      |> assign(:access_token, access_token)
+      |> render("token.json")
+    end
+  end
+end

--- a/lib/web/controllers/oauth/token_controller.ex
+++ b/lib/web/controllers/oauth/token_controller.ex
@@ -2,6 +2,7 @@ defmodule Web.Oauth.TokenController do
   use Web, :controller
 
   alias Grapevine.Authorizations
+  alias Web.ErrorView
 
   def create(conn, params = %{"grant_type" => "authorization_code"}) do
     with {:ok, code} <- Map.fetch(params, "code"),
@@ -11,6 +12,9 @@ defmodule Web.Oauth.TokenController do
       conn
       |> assign(:access_token, access_token)
       |> render("token.json")
+    else
+      _ ->
+        render(conn, ErrorView, "500.json")
     end
   end
 end

--- a/lib/web/controllers/session_controller.ex
+++ b/lib/web/controllers/session_controller.ex
@@ -17,7 +17,7 @@ defmodule Web.SessionController do
         conn
         |> put_flash(:info, "You have signed in.")
         |> put_session(:user_token, user.token)
-        |> redirect(to: page_path(conn, :index))
+        |> after_sign_in_redirect()
 
       {:error, :invalid} ->
         conn
@@ -30,5 +30,17 @@ defmodule Web.SessionController do
     conn
     |> clear_session()
     |> redirect(to: page_path(conn, :index))
+  end
+
+  defp after_sign_in_redirect(conn) do
+    case get_session(conn, :last_path) do
+      nil ->
+        conn |> redirect(to: page_path(conn, :index))
+
+      path ->
+        conn
+        |> put_session(:last_path, nil)
+        |> redirect(to: path)
+    end
   end
 end

--- a/lib/web/controllers/user_controller.ex
+++ b/lib/web/controllers/user_controller.ex
@@ -1,9 +1,12 @@
 defmodule Web.UserController do
   use Web, :controller
 
+  plug(Web.Plugs.VerifyScopes, scope: "profile")
+
   def show(conn, _params) do
     conn
     |> assign(:user, conn.assigns.current_user)
+    |> assign(:scopes, conn.assigns.current_scopes)
     |> render("show.json")
   end
 end

--- a/lib/web/controllers/user_controller.ex
+++ b/lib/web/controllers/user_controller.ex
@@ -1,0 +1,9 @@
+defmodule Web.UserController do
+  use Web, :controller
+
+  def show(conn, _params) do
+    conn
+    |> assign(:user, conn.assigns.current_user)
+    |> render("show.json")
+  end
+end

--- a/lib/web/plugs/ensure_user.ex
+++ b/lib/web/plugs/ensure_user.ex
@@ -3,6 +3,7 @@ defmodule Web.Plugs.EnsureUser do
   Verify a user is in the session
   """
 
+  import Plug.Conn
   import Phoenix.Controller
 
   alias Web.Router.Helpers, as: Routes
@@ -18,6 +19,7 @@ defmodule Web.Plugs.EnsureUser do
         conn
         |> put_flash(:info, "You must sign in first.")
         |> redirect(to: Routes.page_path(conn, :index))
+        |> halt()
     end
   end
 end

--- a/lib/web/plugs/ensure_user.ex
+++ b/lib/web/plugs/ensure_user.ex
@@ -6,9 +6,23 @@ defmodule Web.Plugs.EnsureUser do
   import Plug.Conn
   import Phoenix.Controller
 
+  alias Web.ErrorView
   alias Web.Router.Helpers, as: Routes
 
   def init(default), do: default
+
+  def call(conn, [api: true]) do
+    case conn.assigns do
+      %{current_user: current_user} when current_user != nil ->
+        conn
+
+      _ ->
+        conn
+        |> put_status(401)
+        |> render(ErrorView, "401.json")
+        |> halt()
+    end
+  end
 
   def call(conn, _opts) do
     case conn.assigns do

--- a/lib/web/plugs/ensure_user.ex
+++ b/lib/web/plugs/ensure_user.ex
@@ -30,9 +30,12 @@ defmodule Web.Plugs.EnsureUser do
         conn
 
       _ ->
+        uri = %URI{path: conn.request_path, query: conn.query_string}
+
         conn
         |> put_flash(:info, "You must sign in first.")
-        |> redirect(to: Routes.page_path(conn, :index))
+        |> put_session(:last_path, URI.to_string(uri))
+        |> redirect(to: Routes.session_path(conn, :new))
         |> halt()
     end
   end

--- a/lib/web/plugs/fetch_game.ex
+++ b/lib/web/plugs/fetch_game.ex
@@ -1,0 +1,31 @@
+defmodule Web.Plugs.FetchGame do
+  @moduledoc """
+  Fetch a user from the session
+  """
+
+  import Plug.Conn
+
+  alias Backbone.Games
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    case Map.has_key?(conn.params, "client_id") do
+      true ->
+        fetch_game(conn, conn.params["client_id"])
+
+      false ->
+        conn
+    end
+  end
+
+  defp fetch_game(conn, client_id) do
+    case Games.get_by(client_id: client_id) do
+      {:ok, game} ->
+        assign(conn, :client_game, game)
+
+      {:error, :not_found} ->
+        conn
+    end
+  end
+end

--- a/lib/web/plugs/fetch_user.ex
+++ b/lib/web/plugs/fetch_user.ex
@@ -18,6 +18,7 @@ defmodule Web.Plugs.FetchUser do
           conn
           |> assign(:access_token, access_token)
           |> assign(:current_user, access_token.authorization.user)
+          |> assign(:current_scopes, access_token.authorization.scopes)
         else
           _ ->
             conn

--- a/lib/web/plugs/fetch_user.ex
+++ b/lib/web/plugs/fetch_user.ex
@@ -13,12 +13,12 @@ defmodule Web.Plugs.FetchUser do
   def call(conn, [api: true]) do
     case get_req_header(conn, "authorization") do
       ["Bearer " <> token] ->
-        case Authorizations.get_token(token) do
-          {:ok, access_token} ->
-            conn
-            |> assign(:access_token, access_token)
-            |> assign(:current_user, access_token.authorization.user)
-
+        with {:ok, access_token} <- Authorizations.get_token(token),
+             true <- Authorizations.valid_token?(access_token) do
+          conn
+          |> assign(:access_token, access_token)
+          |> assign(:current_user, access_token.authorization.user)
+        else
           _ ->
             conn
         end

--- a/lib/web/plugs/fetch_user.ex
+++ b/lib/web/plugs/fetch_user.ex
@@ -23,7 +23,7 @@ defmodule Web.Plugs.FetchUser do
             conn
         end
 
-      [] ->
+      _ ->
         conn
     end
   end

--- a/lib/web/plugs/verify_scopes.ex
+++ b/lib/web/plugs/verify_scopes.ex
@@ -1,0 +1,27 @@
+defmodule Web.Plugs.VerifyScopes do
+  @moduledoc """
+  Verify the user has appropriate scopes before requesting the accessed resource
+  """
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias Web.ErrorView
+
+  def init(default), do: default
+
+  def call(conn, opts) do
+    scope = Keyword.get(opts, :scope)
+
+    case scope in conn.assigns.current_scopes do
+      true ->
+        conn
+
+      false ->
+        conn
+        |> put_status(401)
+        |> render(ErrorView, "401.json")
+        |> halt()
+    end
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -23,10 +23,15 @@ defmodule Web.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Web.Plugs.FetchUser, api: true
+  end
+
+  pipeline :api_authenticated do
+    plug Web.Plugs.EnsureUser, api: true
   end
 
   scope "/", Web do
-    pipe_through(:browser)
+    pipe_through([:browser])
 
     get "/", PageController, :index
 
@@ -35,6 +40,12 @@ defmodule Web.Router do
     resources("/register", RegistrationController, only: [:new, :create])
 
     resources("/sign-in", SessionController, only: [:new, :create, :delete], singleton: true)
+  end
+
+  scope "/", Web do
+    pipe_through([:api, :api_authenticated])
+
+    get("/users/me", UserController, :show)
   end
 
   scope "/", Web do

--- a/lib/web/templates/oauth/authorization/_scope_email.html.eex
+++ b/lib/web/templates/oauth/authorization/_scope_email.html.eex
@@ -1,0 +1,3 @@
+<div>
+  <b>View</b> your email.
+</div>

--- a/lib/web/templates/oauth/authorization/_scope_profile.html.eex
+++ b/lib/web/templates/oauth/authorization/_scope_profile.html.eex
@@ -1,0 +1,3 @@
+<div>
+  <b>View</b> your basic profile.
+</div>

--- a/lib/web/templates/oauth/authorization/new.html.eex
+++ b/lib/web/templates/oauth/authorization/new.html.eex
@@ -1,0 +1,19 @@
+<div class="row">
+  <div class="col-md-6 offset-md-3">
+    <h3>Authorize <%= @client_game.name %></h3>
+
+    <p class="lead"><%= @client_game.name %> wants to connect.</p>
+
+    <%= form_tag authorization_path(@conn, :update), [method: :put] do %>
+      <%= hidden_input(:authorization, :id, value: @authorization.id) %>
+      <%= hidden_input(:authorization, :allow, value: true) %>
+      <%= submit "Authorize", class: "btn btn-primary btn-block btn-flat" %>
+    <% end %>
+
+    <%= form_tag authorization_path(@conn, :update), [class: "mt-3", method: :put] do %>
+      <%= hidden_input(:authorization, :id, value: @authorization.id) %>
+      <%= hidden_input(:authorization, :allow, value: false) %>
+      <%= submit "Deny", class: "btn btn-secondary btn-block btn-flat" %>
+    <% end %>
+  </div>
+</div>

--- a/lib/web/templates/oauth/authorization/new.html.eex
+++ b/lib/web/templates/oauth/authorization/new.html.eex
@@ -2,7 +2,13 @@
   <div class="col-md-6 offset-md-3">
     <h3>Authorize <%= @client_game.name %></h3>
 
-    <p class="lead"><%= @client_game.name %> wants to connect.</p>
+    <p class="lead"><%= @client_game.name %> wants to connect with the following permissions:</p>
+
+    <ul>
+      <%= Enum.map(@authorization.scopes, fn scope -> %>
+        <li><%= render("_scope_#{scope}.html") %></li>
+      <% end) %>
+    </ul>
 
     <%= form_tag authorization_path(@conn, :update), [method: :put] do %>
       <%= hidden_input(:authorization, :id, value: @authorization.id) %>

--- a/lib/web/views/oauth/authorization_view.ex
+++ b/lib/web/views/oauth/authorization_view.ex
@@ -1,0 +1,3 @@
+defmodule Web.Oauth.AuthorizationView do
+  use Web, :view
+end

--- a/lib/web/views/oauth/token_view.ex
+++ b/lib/web/views/oauth/token_view.ex
@@ -1,0 +1,7 @@
+defmodule Web.Oauth.TokenView do
+  use Web, :view
+
+  def render("token.json", %{access_token: access_token}) do
+    Map.take(access_token, [:access_token, :refresh_token, :expires_in])
+  end
+end

--- a/lib/web/views/user_view.ex
+++ b/lib/web/views/user_view.ex
@@ -1,7 +1,13 @@
 defmodule Web.UserView do
   use Web, :view
 
-  def render("show.json", %{user: user}) do
-    Map.take(user, [:email])
+  def render("show.json", %{user: user, scopes: scopes}) do
+    case "email" in scopes do
+      true ->
+        Map.take(user, [:uid, :username, :email])
+
+      false ->
+        Map.take(user, [:uid, :username])
+    end
   end
 end

--- a/lib/web/views/user_view.ex
+++ b/lib/web/views/user_view.ex
@@ -1,0 +1,7 @@
+defmodule Web.UserView do
+  use Web, :view
+
+  def render("show.json", %{user: user}) do
+    Map.take(user, [:email])
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "artificery": {:hex, :artificery, "0.2.6", "f602909757263f7897130cbd006b0e40514a541b148d366ad65b89236b93497a", [:mix], [], "hexpm"},
-  "backbone": {:git, "https://github.com/oestrich/gossip-backbone.git", "c6ee42bed45620b3a05102739a366f2cc9724284", []},
+  "backbone": {:git, "https://github.com/oestrich/gossip-backbone.git", "f681606798d84fab1ee912dd4006332ef78c82cd", []},
   "bcrypt_elixir": {:hex, :bcrypt_elixir, "1.1.1", "6b5560e47a02196ce5f0ab3f1d8265db79a23868c137e973b27afef928ed8006", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "artificery": {:hex, :artificery, "0.2.6", "f602909757263f7897130cbd006b0e40514a541b148d366ad65b89236b93497a", [:mix], [], "hexpm"},
-  "backbone": {:git, "https://github.com/oestrich/gossip-backbone.git", "2ba427b9864d3da61cc33e6c323fc0780b50124f", []},
+  "backbone": {:git, "https://github.com/oestrich/gossip-backbone.git", "c6ee42bed45620b3a05102739a366f2cc9724284", []},
   "bcrypt_elixir": {:hex, :bcrypt_elixir, "1.1.1", "6b5560e47a02196ce5f0ab3f1d8265db79a23868c137e973b27afef928ed8006", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},

--- a/priv/repo/migrations/20181101215431_create_oauth_tables.exs
+++ b/priv/repo/migrations/20181101215431_create_oauth_tables.exs
@@ -14,7 +14,8 @@ defmodule Grapevine.Repo.Migrations.CreateOauthTables do
       timestamps()
     end
 
-    create table(:access_tokens) do
+    create table(:access_tokens, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
       add(:authorization_id, references(:authorizations), null: false)
       add(:access_token, :uuid, null: false)
       add(:refresh_token, :uuid, null: false)

--- a/priv/repo/migrations/20181101215431_create_oauth_tables.exs
+++ b/priv/repo/migrations/20181101215431_create_oauth_tables.exs
@@ -8,7 +8,7 @@ defmodule Grapevine.Repo.Migrations.CreateOauthTables do
       add(:redirect_uri, :text, null: false)
       add(:state, :text)
       add(:scopes, {:array, :text}, default: fragment("'{}'"), null: false)
-      add(:code, :uuid, null: false)
+      add(:code, :uuid)
       add(:active, :boolean, default: false, null: false)
 
       timestamps()

--- a/priv/repo/migrations/20181101215431_create_oauth_tables.exs
+++ b/priv/repo/migrations/20181101215431_create_oauth_tables.exs
@@ -1,0 +1,32 @@
+defmodule Grapevine.Repo.Migrations.CreateOauthTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:authorizations) do
+      add(:game_id, references(:games), null: false)
+      add(:user_id, references(:users), null: false)
+      add(:redirect_uri, :text, null: false)
+      add(:state, :text)
+      add(:scopes, {:array, :text}, default: fragment("'{}'"), null: false)
+      add(:code, :uuid, null: false)
+      add(:active, :boolean, default: false, null: false)
+
+      timestamps()
+    end
+
+    create table(:access_tokens) do
+      add(:authorization_id, references(:authorizations), null: false)
+      add(:access_token, :uuid, null: false)
+      add(:refresh_token, :uuid, null: false)
+      add(:active, :boolean, default: false, null: false)
+      add(:expires_in, :integer, null: false)
+
+      timestamps()
+    end
+
+    create index(:authorizations, :code, unique: true)
+
+    create index(:access_tokens, :access_token, unique: true)
+    create index(:access_tokens, :refresh_token, unique: true)
+  end
+end

--- a/priv/repo/migrations/20181102223246_add_uuid_to_users.exs
+++ b/priv/repo/migrations/20181102223246_add_uuid_to_users.exs
@@ -1,0 +1,11 @@
+defmodule Grapevine.Repo.Migrations.AddUuidToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add(:uid, :uuid, default: fragment("uuid_generate_v4()"), null: false)
+    end
+
+    create index(:users, :uid, unique: true)
+  end
+end

--- a/test/grapevine/authorizations/authorization_test.exs
+++ b/test/grapevine/authorizations/authorization_test.exs
@@ -4,13 +4,18 @@ defmodule Grapevine.Authorizations.AuthorizationTest do
   alias Backbone.Games.Game
   alias Grapevine.Authorizations.Authorization
 
-  describe "validations" do
+  describe "redirect_uri validations" do
     test "redirect_uri must be https" do
       changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
       refute changeset.errors[:redirect_uri]
 
       changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "http://example.com/"})
       assert changeset.errors[:redirect_uri]
+    end
+
+    test "redirect_uri can be localhost http" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "http://localhost/"})
+      refute changeset.errors[:redirect_uri]
     end
 
     test "redirect_uri must be a full uri" do
@@ -43,6 +48,19 @@ defmodule Grapevine.Authorizations.AuthorizationTest do
 
       changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/#fragment"})
       assert changeset.errors[:redirect_uri]
+    end
+  end
+
+  describe "scope validations " do
+    test "must be present" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{scopes: ["profile"]})
+      refute changeset.errors[:scopes]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{scopes: []})
+      assert changeset.errors[:scopes]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{scopes: nil})
+      assert changeset.errors[:scopes]
     end
   end
 end

--- a/test/grapevine/authorizations/authorization_test.exs
+++ b/test/grapevine/authorizations/authorization_test.exs
@@ -5,48 +5,50 @@ defmodule Grapevine.Authorizations.AuthorizationTest do
   alias Grapevine.Authorizations.Authorization
 
   describe "redirect_uri validations" do
-    test "redirect_uri must be https" do
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+    setup [:with_game]
+
+    test "redirect_uri must be https", %{game: game} do
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/"})
       refute changeset.errors[:redirect_uri]
 
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "http://example.com/"})
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "http://example.com/"})
       assert changeset.errors[:redirect_uri]
     end
 
-    test "redirect_uri can be localhost http" do
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "http://localhost/"})
+    test "redirect_uri can be localhost http", %{game: game} do
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "http://localhost/"})
       refute changeset.errors[:redirect_uri]
     end
 
-    test "redirect_uri must be a full uri" do
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+    test "redirect_uri must be a full uri", %{game: game} do
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/"})
       refute changeset.errors[:redirect_uri]
 
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://"})
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://"})
       assert changeset.errors[:redirect_uri]
     end
 
-    test "redirect_uri must include a path" do
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+    test "redirect_uri must include a path", %{game: game} do
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/"})
       refute changeset.errors[:redirect_uri]
 
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com"})
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com"})
       assert changeset.errors[:redirect_uri]
     end
 
-    test "redirect_uri must not include a query" do
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+    test "redirect_uri must not include a query", %{game: game} do
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/"})
       refute changeset.errors[:redirect_uri]
 
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/?query"})
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/?query"})
       assert changeset.errors[:redirect_uri]
     end
 
-    test "redirect_uri must not include a fragment" do
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+    test "redirect_uri must not include a fragment", %{game: game} do
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/"})
       refute changeset.errors[:redirect_uri]
 
-      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/#fragment"})
+      changeset = %Authorization{} |> Authorization.create_changeset(game, %{redirect_uri: "https://example.com/#fragment"})
       assert changeset.errors[:redirect_uri]
     end
   end
@@ -62,5 +64,22 @@ defmodule Grapevine.Authorizations.AuthorizationTest do
       changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{scopes: nil})
       assert changeset.errors[:scopes]
     end
+  end
+
+  def with_game(_) do
+    # faking this list for all test examples above, so the examples above are why its failing
+    game = %Game{
+      redirect_uris: [
+        "https://example.com/",
+        "http://example.com",
+        "https://",
+        "https://example.com",
+        "https://example.com/?query",
+        "https://example.com/#fragment",
+        "http://localhost/",
+      ]
+    }
+
+    %{game: game}
   end
 end

--- a/test/grapevine/authorizations/authorization_test.exs
+++ b/test/grapevine/authorizations/authorization_test.exs
@@ -1,0 +1,48 @@
+defmodule Grapevine.Authorizations.AuthorizationTest do
+  use ExUnit.Case
+
+  alias Backbone.Games.Game
+  alias Grapevine.Authorizations.Authorization
+
+  describe "validations" do
+    test "redirect_uri must be https" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+      refute changeset.errors[:redirect_uri]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "http://example.com/"})
+      assert changeset.errors[:redirect_uri]
+    end
+
+    test "redirect_uri must be a full uri" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+      refute changeset.errors[:redirect_uri]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://"})
+      assert changeset.errors[:redirect_uri]
+    end
+
+    test "redirect_uri must include a path" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+      refute changeset.errors[:redirect_uri]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com"})
+      assert changeset.errors[:redirect_uri]
+    end
+
+    test "redirect_uri must not include a query" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+      refute changeset.errors[:redirect_uri]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/?query"})
+      assert changeset.errors[:redirect_uri]
+    end
+
+    test "redirect_uri must not include a fragment" do
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/"})
+      refute changeset.errors[:redirect_uri]
+
+      changeset = %Authorization{} |> Authorization.create_changeset(%Game{}, %{redirect_uri: "https://example.com/#fragment"})
+      assert changeset.errors[:redirect_uri]
+    end
+  end
+end

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -7,7 +7,7 @@ defmodule Grapevine.AuthorizationsTest do
   describe "starting to authenticate" do
     setup [:with_user, :with_game]
 
-    test "successful", %{user: user, game: game} do
+     test "successful", %{user: user, game: game} do
       {:ok, authorization} = Authorizations.start_auth(user, game, %{
         state: "my+state",
         redirect_uri: "https://example.com/oauth/callback",
@@ -16,6 +16,21 @@ defmodule Grapevine.AuthorizationsTest do
       assert authorization.state == "my+state"
       assert authorization.redirect_uri == "https://example.com/oauth/callback"
       assert authorization.scopes == []
+    end
+
+    test "reuses authorizations if one is already active", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+      {:ok, authorization} = Authorizations.authorize(authorization)
+
+      {:ok, new_authorization} = Authorizations.start_auth(user, game, %{
+        "state" => "my+state",
+        "redirect_uri" => "https://example.com/oauth/callback",
+      })
+
+      assert new_authorization.id == authorization.id
     end
 
     test "missing params", %{user: user, game: game} do

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -31,6 +31,20 @@ defmodule Grapevine.AuthorizationsTest do
       assert new_authorization.id == authorization.id
     end
 
+    test "regenerates the authorization's code on reuse", %{user: user, game: game} do
+      authorization = create_authorization(user, game)
+
+      {:ok, _authorization} = Authorizations.mark_as_used(authorization)
+
+      {:ok, new_authorization} = Authorizations.start_auth(user, game, %{
+        "state" => "my+state",
+        "redirect_uri" => "https://example.com/oauth/callback",
+        "scope" => "profile"
+      })
+
+      assert new_authorization.code
+    end
+
     test "does not reuse if scopes are different", %{user: user, game: game} do
       authorization = create_authorization(user, game)
 

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -124,6 +124,13 @@ defmodule Grapevine.AuthorizationsTest do
       assert access_token.access_token
     end
 
+    test "authorization code is good once", %{user: user, game: game} do
+      authorization = create_authorization(user, game)
+
+      {:ok, _access_token} = Authorizations.create_token(game.client_id, authorization.redirect_uri, authorization.code)
+      {:error, :invalid_grant} = Authorizations.create_token(game.client_id, authorization.redirect_uri, authorization.code)
+    end
+
     test "authorization is not active", %{user: user, game: game} do
       {:ok, authorization} = Authorizations.start_auth(user, game, %{
         "state" => "my+state",

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -1,0 +1,149 @@
+defmodule Grapevine.AuthorizationsTest do
+  use Grapevine.DataCase
+
+  alias Grapevine.Authorizations
+  alias Grapevine.Authorizations.Authorization
+
+  describe "starting to authenticate" do
+    setup [:with_user, :with_game]
+
+    test "successful", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      assert authorization.state == "my+state"
+      assert authorization.redirect_uri == "https://example.com/oauth/callback"
+      assert authorization.scopes == []
+    end
+
+    test "missing params", %{user: user, game: game} do
+      {:error, changeset} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+      })
+
+      assert changeset.errors[:redirect_uri]
+    end
+  end
+
+  describe "get a user's authorization" do
+    setup [:with_user, :with_game]
+
+    test "scoped to the user", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      assert {:ok, _authorization} = Authorizations.get(user, authorization.id)
+
+      user = create_user(%{username: "other", email: "other@example.com"})
+      assert {:error, :not_found} = Authorizations.get(user, authorization.id)
+    end
+  end
+
+  describe "mark an authorization as allowed" do
+    setup [:with_user, :with_game]
+
+    test "sets authorization to active", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      {:ok, authorization} = Authorizations.authorize(authorization)
+
+      assert authorization.active
+    end
+  end
+
+  describe "mark an authorization as denied" do
+    setup [:with_user, :with_game]
+
+    test "deletes the authorization", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      {:ok, authorization} = Authorizations.deny(authorization)
+
+      assert {:error, :not_found} = Authorizations.get(user, authorization.id)
+    end
+  end
+
+  describe "redirect uris" do
+    test "authorized uri" do
+      authorization = %Authorization{
+        code: "code",
+        redirect_uri: "https://example.com/oauth/callback",
+        state: "my+state"
+      }
+
+      {:ok, uri} = Authorizations.authorized_redirect_uri(authorization)
+      assert uri == "https://example.com/oauth/callback?code=code&state=my%2Bstate"
+    end
+
+    test "denied uri" do
+      authorization = %Authorization{
+        code: "code",
+        redirect_uri: "https://example.com/oauth/callback",
+        state: "my+state"
+      }
+
+      {:ok, uri} = Authorizations.denied_redirect_uri(authorization)
+      assert uri == "https://example.com/oauth/callback?error=access_denied&state=my%2Bstate"
+    end
+  end
+
+  describe "create an access token for an authorization" do
+    setup [:with_user, :with_game]
+
+    test "create a token", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      {:ok, access_token} = Authorizations.create_token(game.client_id, authorization.redirect_uri, authorization.code)
+
+      assert access_token.access_token
+    end
+
+    test "invalid client id", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      {:error, :invalid_grant} = Authorizations.create_token("invalid", authorization.redirect_uri, authorization.code)
+    end
+
+    test "invalid redirect uri", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      {:error, :invalid_grant} = Authorizations.create_token(game.client_id, "redirect", authorization.code)
+    end
+
+    test "invalid code", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+
+      {:error, :invalid_grant} = Authorizations.create_token(game.client_id, authorization.redirect_uri, "code")
+    end
+  end
+
+  def with_user(_) do
+    %{user: create_user()}
+  end
+
+  def with_game(_) do
+    %{game: cache_game()}
+  end
+end

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -154,11 +154,46 @@ defmodule Grapevine.AuthorizationsTest do
     end
   end
 
+  describe "access token is valid" do
+    setup [:with_user, :with_game, :with_token]
+
+    test "is valid", %{access_token: access_token} do
+      assert Authorizations.valid_token?(access_token)
+    end
+
+    test "after expiration", %{access_token: access_token} do
+      yesterday = Timex.now() |> Timex.shift(days: -1)
+      access_token = %{access_token | inserted_at: yesterday}
+
+      refute Authorizations.valid_token?(access_token)
+    end
+
+    test "authorization is not valid", %{authorization: authorization, access_token: access_token} do
+      authorization
+      |> Ecto.Changeset.change(%{active: false})
+      |> Repo.update!()
+
+      refute Authorizations.valid_token?(access_token)
+    end
+  end
+
   def with_user(_) do
     %{user: create_user()}
   end
 
   def with_game(_) do
     %{game: cache_game()}
+  end
+
+  def with_token(%{user: user, game: game}) do
+    {:ok, authorization} = Authorizations.start_auth(user, game, %{
+      state: "my+state",
+      redirect_uri: "https://example.com/oauth/callback",
+    })
+
+    {:ok, authorization} = Authorizations.authorize(authorization)
+    {:ok, access_token} = Authorizations.create_token(authorization)
+
+    %{authorization: authorization, access_token: access_token}
   end
 end

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -43,6 +43,16 @@ defmodule Grapevine.AuthorizationsTest do
       assert new_authorization.id != authorization.id
     end
 
+    test "invalid if redirect uri does not match a known uri", %{user: user, game: game} do
+      {:error, changeset} = Authorizations.start_auth(user, game, %{
+        "state" => "my+state",
+        "redirect_uri" => "https://example.com/oauth/callbacks",
+        "scope" => "profile"
+      })
+
+      assert changeset.errors[:redirect_uri]
+    end
+
     test "missing params", %{user: user, game: game} do
       {:error, changeset} = Authorizations.start_auth(user, game, %{
         "state" => "my+state",
@@ -188,7 +198,11 @@ defmodule Grapevine.AuthorizationsTest do
   end
 
   def with_game(_) do
-    %{game: cache_game()}
+    game = cache_game(%{
+      "redirect_uris" => ["https://example.com/oauth/callback"]
+    })
+
+    %{game: game}
   end
 
   def with_token(%{user: user, game: game}) do

--- a/test/grapevine/authorizations_test.exs
+++ b/test/grapevine/authorizations_test.exs
@@ -124,6 +124,16 @@ defmodule Grapevine.AuthorizationsTest do
       assert access_token.access_token
     end
 
+    test "authorization is not active", %{user: user, game: game} do
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        "state" => "my+state",
+        "redirect_uri" => "https://example.com/oauth/callback",
+        "scope" => "profile",
+      })
+
+      {:error, :invalid_grant} = Authorizations.create_token(game.client_id, authorization.redirect_uri, authorization.code)
+    end
+
     test "invalid client id", %{user: user, game: game} do
       authorization = create_authorization(user, game)
 

--- a/test/support/auth_conn_case.ex
+++ b/test/support/auth_conn_case.ex
@@ -1,4 +1,6 @@
 defmodule Web.AuthConnCase do
+  @moduledoc false
+
   defmacro __using__(_opts) do
     quote do
       use Web.ConnCase

--- a/test/support/auth_conn_case.ex
+++ b/test/support/auth_conn_case.ex
@@ -1,0 +1,13 @@
+defmodule Web.AuthConnCase do
+  defmacro __using__(_opts) do
+    quote do
+      use Web.ConnCase
+
+      setup %{conn: conn} do
+        user = create_user()
+        conn = conn |> assign(:current_user, user)
+        %{conn: conn, user: user}
+      end
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -20,12 +20,12 @@ defmodule Web.ConnCase do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
       import Web.Router.Helpers
+      import Grapevine.TestHelpers
 
       # The default endpoint for testing
       @endpoint Web.Endpoint
     end
   end
-
 
   setup tags do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Grapevine.Repo)
@@ -34,5 +34,4 @@ defmodule Web.ConnCase do
     end
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
-
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -24,6 +24,8 @@ defmodule Grapevine.TestHelpers do
       "display_name" => "Updated",
       "display" => true,
       "allow_character_registration" => true,
+      "client_id" => UUID.uuid4(),
+      "client_secret" => UUID.uuid4(),
     }, attributes)
 
     Games.cache_remote([attributes])

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -27,6 +27,9 @@ defmodule Grapevine.TestHelpers do
       "allow_character_registration" => true,
       "client_id" => UUID.uuid4(),
       "client_secret" => UUID.uuid4(),
+      "redirect_uris" => [
+        "https://example.com/oauth/callback"
+      ]
     }, attributes)
 
     Games.cache_remote([attributes])

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,8 +1,9 @@
 defmodule Grapevine.TestHelpers do
   @moduledoc false
 
-  alias Grapevine.Accounts
   alias Backbone.Games
+  alias Grapevine.Accounts
+  alias Grapevine.Authorizations
 
   def create_user(attributes \\ %{}) do
     attributes = Map.merge(%{
@@ -32,5 +33,16 @@ defmodule Grapevine.TestHelpers do
 
     {:ok, game} = Games.get_by_name(attributes["game"])
     game
+  end
+
+  def create_authorization(user, game) do
+    {:ok, authorization} = Authorizations.start_auth(user, game, %{
+      "state" => "my+state",
+      "redirect_uri" => "https://example.com/oauth/callback",
+      "scope" => "profile"
+    })
+    {:ok, authorization} = Authorizations.authorize(authorization)
+
+    authorization
   end
 end

--- a/test/web/controllers/oauth/authorization_controller_test.exs
+++ b/test/web/controllers/oauth/authorization_controller_test.exs
@@ -5,6 +5,37 @@ defmodule Web.Oauth.AuthorizationControllerTest do
 
   setup [:with_game]
 
+  describe "starting to authorize" do
+    test "first time", %{conn: conn, game: game} do
+      params = %{
+        client_id: game.client_id,
+        state: "state",
+        redirect_uri: "https://example.com/oauth/callback",
+        response_type: "code",
+      }
+
+      conn = get(conn, authorization_path(conn, :new), params)
+
+      assert html_response(conn, 200)
+    end
+
+    test "existing authorization", %{conn: conn, user: user, game: game} do
+      authorization = create_authorization(user, game)
+      {:ok, authorization} = Authorizations.authorize(authorization)
+
+      params = %{
+        client_id: game.client_id,
+        state: "state",
+        redirect_uri: authorization.redirect_uri,
+        response_type: "code",
+      }
+
+      conn = get(conn, authorization_path(conn, :new), params)
+
+      assert redirected_to(conn)
+    end
+  end
+
   describe "authorizing a connection" do
     test "with appropriate connection", %{conn: conn, user: user, game: game} do
       authorization = create_authorization(user, game)

--- a/test/web/controllers/oauth/authorization_controller_test.exs
+++ b/test/web/controllers/oauth/authorization_controller_test.exs
@@ -1,0 +1,39 @@
+defmodule Web.Oauth.AuthorizationControllerTest do
+  use Web.AuthConnCase
+
+  alias Grapevine.Authorizations
+
+  setup [:with_game]
+
+  describe "authorizing a connection" do
+    test "with appropriate connection", %{conn: conn, user: user, game: game} do
+      authorization = create_authorization(user, game)
+
+      conn = patch(conn, authorization_path(conn, :update), authorization: %{id: authorization.id, allow: "true"})
+
+      assert redirected_to(conn) == "https://example.com/oauth/callback?code=#{authorization.code}&state=my%2Bstate"
+    end
+  end
+
+  describe "denying a connection" do
+    test "with appropriate connection", %{conn: conn, user: user, game: game} do
+      authorization = create_authorization(user, game)
+
+      conn = patch(conn, authorization_path(conn, :update), authorization: %{id: authorization.id, allow: "false"})
+
+      assert redirected_to(conn) == "https://example.com/oauth/callback?error=access_denied&state=my%2Bstate"
+    end
+  end
+
+  def with_game(_) do
+    %{game: cache_game()}
+  end
+
+  def create_authorization(user, game) do
+    {:ok, authorization} = Authorizations.start_auth(user, game, %{
+      state: "my+state",
+      redirect_uri: "https://example.com/oauth/callback",
+    })
+    authorization
+  end
+end

--- a/test/web/controllers/oauth/authorization_controller_test.exs
+++ b/test/web/controllers/oauth/authorization_controller_test.exs
@@ -12,6 +12,7 @@ defmodule Web.Oauth.AuthorizationControllerTest do
         state: "state",
         redirect_uri: "https://example.com/oauth/callback",
         response_type: "code",
+        scope: "profile email"
       }
 
       conn = get(conn, authorization_path(conn, :new), params)
@@ -58,13 +59,5 @@ defmodule Web.Oauth.AuthorizationControllerTest do
 
   def with_game(_) do
     %{game: cache_game()}
-  end
-
-  def create_authorization(user, game) do
-    {:ok, authorization} = Authorizations.start_auth(user, game, %{
-      state: "my+state",
-      redirect_uri: "https://example.com/oauth/callback",
-    })
-    authorization
   end
 end

--- a/test/web/controllers/user_controller_test.exs
+++ b/test/web/controllers/user_controller_test.exs
@@ -8,11 +8,7 @@ defmodule Web.UserControllerTest do
       user = create_user()
       game = cache_game()
 
-      {:ok, authorization} = Authorizations.start_auth(user, game, %{
-        state: "my+state",
-        redirect_uri: "https://example.com/oauth/callback",
-      })
-      {:ok, authorization} = Authorizations.authorize(authorization)
+      authorization = create_authorization(user, game)
 
       {:ok, access_token} = Authorizations.create_token(game.client_id, authorization.redirect_uri, authorization.code)
 

--- a/test/web/controllers/user_controller_test.exs
+++ b/test/web/controllers/user_controller_test.exs
@@ -1,0 +1,40 @@
+defmodule Web.UserControllerTest do
+  use Web.ConnCase
+
+  alias Grapevine.Authorizations
+
+  describe "view yourself" do
+    test "correct token", %{conn: conn} do
+      user = create_user()
+      game = cache_game()
+
+      {:ok, authorization} = Authorizations.start_auth(user, game, %{
+        state: "my+state",
+        redirect_uri: "https://example.com/oauth/callback",
+      })
+      {:ok, authorization} = Authorizations.authorize(authorization)
+
+      {:ok, access_token} = Authorizations.create_token(game.client_id, authorization.redirect_uri, authorization.code)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{access_token.access_token}")
+        |> put_req_header("accept", "application/json")
+
+      conn = get(conn, user_path(conn, :show))
+
+      assert json_response(conn, 200)
+    end
+
+    test "bad token", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{UUID.uuid4()}")
+        |> put_req_header("accept", "application/json")
+
+      conn = get(conn, user_path(conn, :show))
+
+      assert json_response(conn, 401)
+    end
+  end
+end

--- a/test/web/plugs/verify_scopes_test.exs
+++ b/test/web/plugs/verify_scopes_test.exs
@@ -1,0 +1,19 @@
+defmodule Web.Plugs.VerifyScopesTest do
+  use Web.ConnCase
+
+  alias Web.Plugs.VerifyScopes
+
+  describe "denies requests with missing scopes" do
+    test "scope is present passes through", %{conn: conn} do
+      conn = assign(conn, :current_scopes, ["profile"])
+      conn = VerifyScopes.call(conn, [scope: "profile"])
+      refute conn.status
+    end
+
+    test "halts requests with missing scopes", %{conn: conn} do
+      conn = assign(conn, :current_scopes, ["profile"])
+      conn = VerifyScopes.call(conn, [scope: "email"])
+      assert conn.status == 401
+    end
+  end
+end


### PR DESCRIPTION
This starts on an OAuth provider for the Gossip network. Grapevine will be a new way of authenticating against a game.

TODO:
- [x] authorization redirects need to be a proper `https` only URI
- [x] games should have a white list of allowed redirect uris, again valid `https` only
- [x] access tokens only generate for active authorizations
- [x] authorization code is valid once
- [x] handle client id not found, redirect back with an error
- [x] scopes
  - [x] `profile`, basic profile information `uid`, `username`
  - [x] `email`, upgraded `profile` to include `email`
- [x] re-authorize should clear previous tokens

New PR:
- [ ] view active authorizations
  - [ ] deactivate them